### PR TITLE
Remove createdAt field in Event

### DIFF
--- a/base/src/main/java/info/metadude/kotlin/library/c3media/models/Event.kt
+++ b/base/src/main/java/info/metadude/kotlin/library/c3media/models/Event.kt
@@ -10,8 +10,6 @@ data class Event(
         val conferenceId: Int? = null,
         @Json(name = "conference_url")
         val conferenceUrl: String? = null,
-        @Json(name = "created_at")
-        val createdAt: OffsetDateTime? = null,
         val date: OffsetDateTime? = null,
         val description: String? = null,
         @Json(name = "downloaded_recordings_count")

--- a/base/src/test/java/info/metadude/kotlin/library/c3media/ProductionApiTest.kt
+++ b/base/src/test/java/info/metadude/kotlin/library/c3media/ProductionApiTest.kt
@@ -169,7 +169,6 @@ class ProductionApiTest {
         assertThat(event.guid).isNotNull()
         // assertThat(event.posterFilename).isNotNull()
         // assertThat(event.conferenceId).isNotNull()
-        // assertThat(event.createdAt).isNotNull()
         assertThat(event.updatedAt).isNotNull()
         assertThat(event.title).isNotNull()
         // assertThat(event.thumbFilename).isNotNull()


### PR DESCRIPTION
- because it does not exist in api.media.ccc.de
Closes #4