### PR TITLE
Adds event last released at

### DIFF
--- a/base/src/main/java/info/metadude/kotlin/library/c3media/models/Conference.kt
+++ b/base/src/main/java/info/metadude/kotlin/library/c3media/models/Conference.kt
@@ -1,6 +1,7 @@
 package info.metadude.kotlin.library.c3media.models
 
 import com.squareup.moshi.Json
+import org.threeten.bp.LocalDate
 import org.threeten.bp.OffsetDateTime
 
 data class Conference(
@@ -21,6 +22,8 @@ data class Conference(
         val title: String? = null,
         @Json(name = "updated_at")
         val updatedAt: OffsetDateTime? = null,
+        @Json(name = "event_last_released_at")
+        val eventLastReleasedAt: LocalDate? = null,
         val url: String? = null,
         @Json(name = "webgen_location")
         val webgenLocation: String? = null

--- a/base/src/main/java/info/metadude/kotlin/library/c3media/models/Metadata.kt
+++ b/base/src/main/java/info/metadude/kotlin/library/c3media/models/Metadata.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 
 data class Metadata(
 
-        val related: List<Int>? = null,
+//        val related: List<Int>? = null,
         @Json(name = "remote_id")
         val remoteId: Int? = null
 


### PR DESCRIPTION
Hey Tobi, 

the API added a new field `eventLastReleasedAt ` to conferences which I am adding in this PR. 

Also quite old but I have not submitted it yet: parsing related Events in Metadata is broken (as you already know) and I removed this field temporarily.