### PR TITLE
adds new field `eventLastReleasedAt` to Conference

### DIFF
--- a/base/src/main/java/info/metadude/kotlin/library/c3media/models/Conference.kt
+++ b/base/src/main/java/info/metadude/kotlin/library/c3media/models/Conference.kt
@@ -1,6 +1,7 @@
 package info.metadude.kotlin.library.c3media.models
 
 import com.squareup.moshi.Json
+import org.threeten.bp.LocalDate
 import org.threeten.bp.OffsetDateTime
 
 data class Conference(
@@ -8,6 +9,8 @@ data class Conference(
         val acronym: String,
         @Json(name = "aspect_ratio")
         val aspectRatio: AspectRatio? = null,
+        @Json(name = "event_last_released_at")
+        val eventLastReleasedAt: LocalDate? = null,
         val events: List<Event?>? = null,
         @Json(name = "images_url")
         val imagesUrl: String? = null,

--- a/base/src/test/java/info/metadude/kotlin/library/c3media/ProductionApiTest.kt
+++ b/base/src/test/java/info/metadude/kotlin/library/c3media/ProductionApiTest.kt
@@ -48,6 +48,8 @@ class ProductionApiTest {
         // assertThat(aspectRatio).isNotNull()
         //        .isNotEqualTo(AspectRatio.UNKNOWN)
         assertThat(updatedAt).isNotNull()
+        // Currently three conferences return "eventLastReleasedAt": null.
+        // assertThat(eventLastReleasedAt).isNotNull()
         assertThat(title).isNotNull()
         // assertThat(scheduleUrl).isNotNull()
         assertThat(slug).isNotNull()
@@ -80,6 +82,7 @@ class ProductionApiTest {
         assertThat(aspectRatio).isNotNull()
                 .isNotEqualTo(AspectRatio.UNKNOWN)
         assertThat(updatedAt).isNotNull()
+        assertThat(eventLastReleasedAt).isNotNull()
         assertThat(title).isNotNull()
         // conference.scheduleUrl can be null
         assertThat(slug).isNotNull()


### PR DESCRIPTION
Here is a new PR for `eventLastReleasedAt`.  I will close the [old one](https://github.com/johnjohndoe/c3media-base/pull/6) which also had changes on the metadata parsing in it.