### PR TITLE
Fix Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:


### PR DESCRIPTION
+ Use Trusty (14.04) distribution which has Java 8 preinstalled.
+ See: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment.