### PR TITLE
Customize user agent to let the API identify requests made by the library

### DIFF
--- a/base/src/main/java/info/metadude/kotlin/library/c3media/UserAgentInterceptor.kt
+++ b/base/src/main/java/info/metadude/kotlin/library/c3media/UserAgentInterceptor.kt
@@ -1,0 +1,19 @@
+package info.metadude.kotlin.library.c3media
+
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+import java.io.IOException
+
+class UserAgentInterceptor(private val userAgent: String) : Interceptor {
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Chain): Response {
+        val originalRequest = chain.request()
+        val requestWithUserAgent = originalRequest.newBuilder()
+                .header("User-Agent", userAgent)
+                .build()
+        return chain.proceed(requestWithUserAgent)
+    }
+
+}

--- a/base/src/test/java/info/metadude/kotlin/library/c3media/ProductionApiTest.kt
+++ b/base/src/test/java/info/metadude/kotlin/library/c3media/ProductionApiTest.kt
@@ -415,6 +415,7 @@ class ProductionApiTest {
         val interceptor = HttpLoggingInterceptor()
         interceptor.level = HttpLoggingInterceptor.Level.NONE
         val okHttpClient = OkHttpClient.Builder()
+                .addNetworkInterceptor(UserAgentInterceptor("c3media-base library; ${javaClass.simpleName}"))
                 .addNetworkInterceptor(interceptor)
                 .build()
         ApiModule.provideC3MediaService(BASE_URL, okHttpClient)


### PR DESCRIPTION
+ Provide `UserAgentInterceptor` class to be used by client apps.
+ Related: https://github.com/stefanmedack/cccTV/issues/32.